### PR TITLE
fix: derive admin base URL from current location instead of hardcoding /admin/

### DIFF
--- a/asset/js/webmcp-resources.js
+++ b/asset/js/webmcp-resources.js
@@ -20,7 +20,14 @@
         return;
     }
 
-    const _proxyUrl = (window.WebMCPConfig && window.WebMCPConfig.proxy_url) || '/admin/webmcp/proxy';
+    const _proxyUrl = (window.WebMCPConfig && window.WebMCPConfig.proxy_url) || (function () {
+        // Fallback: derive admin base from current location to support subdirectory deployments.
+        try {
+            var idx = window.location.pathname.indexOf('/admin/');
+            if (idx !== -1) return window.location.pathname.substring(0, idx) + '/admin/webmcp/proxy';
+        } catch (e) {}
+        return '/admin/webmcp/proxy';
+    }());
 
     /**
      * Retrieve the CSRF token injected by PHP into window.WebMCPConfig.

--- a/asset/js/webmcp.js
+++ b/asset/js/webmcp.js
@@ -33,7 +33,14 @@
     const groupUsers       = config.users        === true;
     const groupVocabs      = config.vocabularies === true;
     const groupBulk        = config.bulk         === true;
-    const _proxyUrl        = config.proxy_url    || '/admin/webmcp/proxy';
+    const _proxyUrl        = config.proxy_url    || (function () {
+        // Fallback: derive admin base from current location to support subdirectory deployments.
+        try {
+            var idx = window.location.pathname.indexOf('/admin/');
+            if (idx !== -1) return window.location.pathname.substring(0, idx) + '/admin/webmcp/proxy';
+        } catch (e) {}
+        return '/admin/webmcp/proxy';
+    }());
 
     /**
      * Retrieve the CSRF token injected by PHP into window.WebMCPConfig.
@@ -498,7 +505,14 @@
             execute: async (input) => {
                 try {
                     // Navigate to the item edit page so the user can upload via the form.
-                    window.location.href = `/admin/item/${input.item_id}/edit#media`;
+                    // Derive the admin base from _proxyUrl to support subdirectory deployments.
+                    var adminBase = '/admin';
+                    try {
+                        var proxyPath = new URL(_proxyUrl, window.location.href).pathname;
+                        var adminIdx = proxyPath.indexOf('/admin/');
+                        if (adminIdx !== -1) adminBase = proxyPath.substring(0, adminIdx + '/admin'.length);
+                    } catch (e) {}
+                    window.location.href = adminBase + '/item/' + input.item_id + '/edit#media';
                     return { success: true, message: `Navigated to item #${input.item_id} edit page for media upload.` };
                 } catch (err) {
                     return errorResult(err);


### PR DESCRIPTION
## Summary

Three places in the client-side JS assumed Omeka S is mounted at the site root, breaking deployments installed under a path prefix (e.g. `/omeka/admin/…`):

1. **`webmcp.js` – `_proxyUrl` fallback**: used the literal `'/admin/webmcp/proxy'` when `window.WebMCPConfig.proxy_url` was unavailable.
2. **`webmcp.js` – `add-media-upload` execute callback**: always navigated to the hardcoded path `` `/admin/item/${id}/edit#media` ``, regardless of path prefix.
3. **`webmcp-resources.js` – `_proxyUrl` fallback**: same issue as (1).

## Fix

- **Fallbacks (1 & 3)**: replaced with an IIFE that looks for `/admin/` in `window.location.pathname` and prepends whatever prefix precedes it; falls back to `'/admin/webmcp/proxy'` for root installs.
- **Navigation (2)**: replaced the template literal with a derivation of the admin base path from `_proxyUrl` (which PHP always generates correctly via the Laminas route helper). A safe try/catch guards against URL-parse failures and falls back to `'/admin'` for root installs.

## Test plan

- [ ] Verify proxy requests reach the correct endpoint on a root install
- [ ] Verify proxy requests reach the correct endpoint on a subdirectory install (`/omeka/admin/webmcp/proxy`)
- [ ] Verify the add-media-upload tool navigates to the correct item edit URL on both install types